### PR TITLE
Allow Exec() without init the executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ instead of recompiling/restarting everything.
 Caveat: the old process will continue running happily if `go install` has a
 compile error, so if you missed any compile errors due to switching the window
 too soon you may get confused.
+
+You can also use `reload.Exec()` to manually restart your process, instead of 
+automatically restarting when a file changes. 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/reload.go
+++ b/reload.go
@@ -159,7 +159,16 @@ func Do(log func(string, ...interface{}), additional ...dir) error {
 
 // Exec replaces the current process with a new copy of itself.
 func Exec() {
-	err := syscall.Exec(binSelf, append([]string{binSelf}, os.Args[1:]...), os.Environ())
+	execName := binSelf
+	if execName == "" {
+		selfName, err := self()
+		if err != nil {
+			panic(fmt.Sprintf("cannot restart: cannot find self: %v", err))
+		}
+		execName = selfName
+	}
+
+	err := syscall.Exec(execName, append([]string{execName}, os.Args[1:]...), os.Environ())
 	if err != nil {
 		panic(fmt.Sprintf("cannot restart: %v", err))
 	}


### PR DESCRIPTION
We use this library in a project (https://github.com/checkr/openmock) that uses go templates, and it's very handy to watch for the template files to change so we can reload everything.  We also have an API interface that lets you manually set the same models, so it's convenient to store those in redis and then `Exec()` to reload the whole process.  We've found that in local development, we run into problems with the file handles opened by `reload` don't get dropped when you restart the process, and after a few reloads it crashes with an error like:
```
FATA[0000] cannot add "/Users/sesquipedalian.dev/Documents/go_repos/src/github.com/checkr/openmock" to watcher: too many open files 
```

So, we added a configuration that lets you skip the initialization of reload (`reload.Do`), but in this case `reload.Exec` crashes because `binSelf` has not been set.  This PR makes it so `Exec` will just figure out the executable name when called instead of needing to be initialized.  This is handy if you want to use this 'crash-only software' style of reloading your program's data. 

