### PR TITLE
Update fsnotify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language:       go
-go:             ['1.14.x', '1.15.x']
+go:             ['1.16.x', '1.17.x', '1.18.x', '1.19.x']
 go_import_path: github.com/teamwork/reload
 jobs:
   include:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
 module github.com/teamwork/reload
 
-go 1.13
+go 1.16
 
-require (
-	github.com/fsnotify/fsnotify v1.4.9
-	golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 // indirect
-)
+require github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
-github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Update github.com/fsnotify/fsnotify to the latest version; this fixes a bunch of bugs.

Also update Go version to 1.16; it already used %w fmt.Errorf(), so that was already required.