### PR TITLE
Add OnExec()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language:       go
-go:             ['1.16.x', '1.17.x', '1.18.x', '1.19.x']
+go:             ['1.18.x', '1.19.x']
 go_import_path: github.com/teamwork/reload
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 Lightweight automatic reloading of Go processes.
 
-After initialisation with `reload.Do()` any changes to the binary (and *only*
-the binary) will restart the process. For example:
+After initialisation with `reload.Do()` any changes to the binary will restart
+the process. For example:
 
 ```go
 func main() {
@@ -38,6 +38,9 @@ func main() {
     }()
 }
 ```
+
+This will run reloadTpl if any file in the "tpl" directory changes. The process
+won't be restarted.
 
 You can also use `reload.Exec()` to manually restart your process without
 calling `reload.Do()`.

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/teamwork/reload
 
-go 1.16
+go 1.18
 
 require github.com/fsnotify/fsnotify v1.6.0
+
+require golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect


### PR DESCRIPTION
syscall.Exec() will unapologetically replace/kill the current process. This is good in many cases, but in some cases you really want to run some code before it does so.

In my case, the Go backend also starts a webpack nodejs process to rebuild the frontend on changes, but the node process will keep running as an orphan because the parent died. With OnExec() the parent can instruct the children to kill themselves. There are probably some other use cases as well.

It would be nicer to add this to reload.Do(), but we can't really do that without an incompatible change.