### PR TITLE
Enable directory recursion in Dir()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ func main() {
 }
 ```
 
-If the path argument to `reload.Dir()` contains a trailing slash, the directory will be evaluated recursively.
+If the path argument to `reload.Dir()` ends with /... or \..., the directory will be evaluated recursively.
 
 You can also use `reload.Exec()` to manually restart your process without
 calling `reload.Do()`.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ func main() {
 }
 ```
 
+If the path argument to `reload.Dir()` contains a trailing slash, the directory will be evaluated recursively.
+
 You can also use `reload.Exec()` to manually restart your process without
 calling `reload.Do()`.
 

--- a/reload.go
+++ b/reload.go
@@ -5,21 +5,21 @@
 //
 // Example:
 //
-//    go func() {
-//        err := reload.Do(log.Printf)
-//        if err != nil {
-//            panic(err)
-//        }
-//    }()
+//	go func() {
+//	    err := reload.Do(log.Printf)
+//	    if err != nil {
+//	        panic(err)
+//	    }
+//	}()
 //
 // A list of additional directories to watch can be added:
 //
-//    go func() {
-//        err := reload.Do(log.Printf, reload.Dir("tpl", reloadTpl)
-//        if err != nil {
-//            panic(err)
-//        }
-//    }()
+//	go func() {
+//	    err := reload.Do(log.Printf, reload.Dir("tpl", reloadTpl)
+//	    if err != nil {
+//	        panic(err)
+//	    }
+//	}()
 //
 // Note that this package won't prevent race conditions (e.g. when assigning to
 // a global templates variable). You'll need to use sync.RWMutex yourself.
@@ -157,8 +157,10 @@ func Do(log func(string, ...interface{}), additional ...dir) error {
 func expandAdditional(log func(string, ...interface{}), additional []dir) []dir {
 	result := make([]dir, 0, len(additional))
 	for _, a := range additional {
-		if lastChar := a.path[len(a.path)-1]; lastChar == '\\' || lastChar == '/' {
-			result = append(result, listDirs(log, a.path, a.cb)...)
+		if strings.HasSuffix(a.path, "\\...") {
+			result = append(result, listDirs(log, strings.TrimSuffix(a.path, "\\..."), a.cb)...)
+		} else if strings.HasSuffix(a.path, "/...") {
+			result = append(result, listDirs(log, strings.TrimSuffix(a.path, "/..."), a.cb)...)
 		} else {
 			result = append(result, a)
 		}

--- a/reload.go
+++ b/reload.go
@@ -27,6 +27,7 @@ package reload // import "github.com/teamwork/reload"
 
 import (
 	"fmt"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -205,4 +206,18 @@ func relpath(p string) string {
 	}
 
 	return p
+}
+
+func ListDirs(rootPath string, cb func()) (result []dir) {
+	filepath.WalkDir(rootPath, func(dirPath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return fs.SkipDir
+		}
+		if d.IsDir() {
+			result = append(result, Dir(dirPath, cb))
+		}
+		return nil
+	})
+
+	return
 }


### PR DESCRIPTION
Interface is as you described in issue #10. Because it doesn't have access to the logger supplied to reload.Do(), it's just silently skipping directories that encounter a read error. 

Since the actual directories monitored are listed by do(), I didn't think this was that big a deal, but happy to try something else if you'd like these errors to be surfaced.

Thanks for the library, it's working really well for me!